### PR TITLE
feat: add configurable TTL and cache toggle to CacheConfig

### DIFF
--- a/src/main/java/com/applyflow/config/CacheConfig.java
+++ b/src/main/java/com/applyflow/config/CacheConfig.java
@@ -1,6 +1,11 @@
 package com.applyflow.config;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
@@ -17,33 +22,59 @@ import java.time.Duration;
 
 @Configuration
 @EnableCaching
+@Slf4j
 public class CacheConfig {
 
-    private static final String CACHE_APPLICATIONS = "applications";
-    private static final String CACHE_USER_APPLICATIONS = "userApplications";
+        private static final String CACHE_APPLICATIONS = "applications";
+        private static final String CACHE_USER_APPLICATIONS = "userApplications";
 
-    @Bean
-    @Profile("prod")
-    public CacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
-        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(10))
-                .serializeValuesWith(
-                        RedisSerializationContext.SerializationPair
-                                .fromSerializer(new GenericJackson2JsonRedisSerializer()))
-                .disableCachingNullValues();
+        @Value("${application.cache.ttl-seconds:60}")
+        private long ttlSeconds;
 
-        return RedisCacheManager.builder(connectionFactory)
-                .cacheDefaults(config)
-                .withCacheConfiguration(CACHE_APPLICATIONS,
-                        RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(5)))
-                .withCacheConfiguration(CACHE_USER_APPLICATIONS,
-                        RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(5)))
-                .build();
-    }
+        @Value("${application.cache.enabled:true}")
+        private boolean cacheEnabled;
 
-    @Bean
-    @Profile("!prod")
-    public CacheManager simpleCacheManager() {
-        return new ConcurrentMapCacheManager(CACHE_APPLICATIONS, CACHE_USER_APPLICATIONS);
-    }
+        @Bean
+        @Profile("prod")
+        public CacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+                if (!cacheEnabled) {
+                        log.info("Cache is disabled, using no-op cache manager");
+                        return new ConcurrentMapCacheManager();
+                }
+
+                ObjectMapper cacheMapper = new ObjectMapper();
+                cacheMapper.registerModule(new JavaTimeModule());
+                cacheMapper.activateDefaultTyping(
+                                LaissezFaireSubTypeValidator.instance,
+                                ObjectMapper.DefaultTyping.NON_FINAL,
+                                JsonTypeInfo.As.PROPERTY);
+
+                GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(cacheMapper);
+
+                RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                                .entryTtl(Duration.ofSeconds(ttlSeconds))
+                                .serializeValuesWith(
+                                                RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+                                .disableCachingNullValues();
+
+                log.info("Redis cache configured with TTL={}s, enabled={}", ttlSeconds, cacheEnabled);
+
+                return RedisCacheManager.builder(connectionFactory)
+                                .cacheDefaults(defaultConfig)
+                                .withCacheConfiguration(CACHE_APPLICATIONS,
+                                                defaultConfig.entryTtl(Duration.ofSeconds(ttlSeconds)))
+                                .withCacheConfiguration(CACHE_USER_APPLICATIONS,
+                                                defaultConfig.entryTtl(Duration.ofSeconds(ttlSeconds)))
+                                .build();
+        }
+
+        @Bean
+        @Profile("!prod")
+        public CacheManager simpleCacheManager() {
+                if (!cacheEnabled) {
+                        log.info("Cache is disabled in non-prod profile");
+                        return new ConcurrentMapCacheManager();
+                }
+                return new ConcurrentMapCacheManager(CACHE_APPLICATIONS, CACHE_USER_APPLICATIONS);
+        }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,10 @@ application:
     requests-per-minute: 30
     auth-requests-per-minute: 10
 
+  cache:
+    ttl-seconds: ${CACHE_TTL:60}
+    enabled: ${CACHE_ENABLED:true}
+
   reminder:
     enabled: false
     stale-days: 7


### PR DESCRIPTION
# Redis Caching

## 1. Overview

This document defines the caching strategy for ApplyFlow using Redis.

The goal is to improve performance, reduce database load, and prepare the system for higher traffic scenarios.

Redis caching will be implemented selectively for read-heavy endpoints.

---

## 2. Problem Statement

Currently, every read operation hits the database directly.

As traffic grows, this leads to:

- Increased database load
- Slower response times
- Reduced scalability
- Higher infrastructure costs

Caching frequently accessed data reduces database pressure and improves response latency.

---

## 3. Goals

- Cache read-heavy endpoints
- Reduce database load
- Improve API response time
- Ensure cache invalidation consistency
- Maintain data correctness
- Work safely in distributed environments

---

## 4. Non-Goals

- Full query caching
- Distributed multi-region caching
- Complex cache clustering setup
- Event sourcing implementation
- CQRS architecture

---

## 5. Caching Strategy

### 5.1 What Will Be Cached

Initial scope:

- GET /jobs (filtered results included)
- GET /jobs/{id}
- Analytics endpoints (if implemented)

Write operations will NOT be cached.

---

### 5.2 Cache Key Design

Key pattern:

jobs:{user_id}:{filters_hash}

Example:

jobs:42:status=applied
jobs:42:all
job:42:job_id=123

Principles:

- Include user_id to ensure isolation
- Include filter hash to support query variations
- Use predictable structure

---

### 5.3 TTL (Time-To-Live)

Default TTL:

60 seconds

Configurable via:

CACHE_TTL=60

Rationale:

- Balance between freshness and performance
- Avoid stale data risk

---

### 5.4 Cache Invalidation Strategy

Critical design decision.

Cache must be invalidated when:

- Job is created
- Job is updated
- Job is deleted
- Status changes

Strategy:

- On write operation:
  - Delete all related keys for that user

Example:

DELETE jobs:{user_id}:*

Tradeoff:

Slight over-invalidation is acceptable to maintain consistency.

---

### 5.5 Implementation Flow

Read request:

1. Generate cache key
2. Check Redis
3. If hit → return cached response
4. If miss → query database
5. Store result in Redis with TTL
6. Return response

Write request:

1. Perform DB operation
2. Invalidate related cache keys
3. Return response

---

## 6. Serialization Strategy

Cache data format:

- JSON serialized response
- Same structure as API response

Benefits:

- No transformation required on return
- Consistent output
- Easy debugging

---

## 7. Security Considerations

- Cache keys must include user_id
- Never cache sensitive data like:
  - Passwords
  - Refresh tokens
- Avoid exposing internal Redis instance
- Protect Redis with internal Docker network

---

## 8. Performance Considerations

Benefits:

- O(1) lookup
- Reduced DB queries
- Lower response time

Potential Risks:

- Cache stampede
- Over-invalidation
- Redis memory growth

Mitigation:

- TTL enforcement
- Memory limits on Redis
- Monitor cache hit ratio

---

## 9. Edge Cases

- Redis temporarily unavailable
- Cache contains stale data
- Simultaneous write + read operations
- Multiple filters generating many keys

Fallback strategy:

If Redis is unavailable:
- Log warning
- Proceed with DB query (fail-open strategy)

---

## 10. Testing Strategy

Unit Tests:

- Cache key generation
- TTL behavior
- Invalidation logic

Integration Tests:

- Confirm cache hit
- Confirm cache miss
- Confirm invalidation after update
- Confirm fallback if Redis down

Performance Tests:

- Compare DB-only vs cache-enabled latency

---

## 11. Configuration

Environment variables:

REDIS_URL
CACHE_TTL=60

Optional:

CACHE_ENABLED=true

---

## 12. Observability

Optional enhancement:

- Track cache hit rate
- Track cache miss rate
- Log cache behavior (debug mode)

Future enhancement:

- Add metrics endpoint

---

## 13. Acceptance Criteria

- [X] Read-heavy endpoints cached
- [X] Cache keys include user_id
- [X] TTL implemented
- [X] Cache invalidated on writes
- [X] Redis failure fallback implemented
- [X] Covered by automated tests
- [X] Configurable via environment variables